### PR TITLE
Annotation processors should always report the latest version...

### DIFF
--- a/src/main/java/org/kohsuke/metainf_services/AnnotationProcessorImpl.java
+++ b/src/main/java/org/kohsuke/metainf_services/AnnotationProcessorImpl.java
@@ -37,7 +37,6 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
@@ -56,8 +55,11 @@ import org.kohsuke.MetaInfServices;
  */
 @SuppressWarnings({"Since15"})
 @SupportedAnnotationTypes("org.kohsuke.MetaInfServices")
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class AnnotationProcessorImpl extends AbstractProcessor {
+
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {


### PR DESCRIPTION
as this compat mechanism was ill-conceived and impossible to use reliably in a forward-compatible manner.

It is better to risk (the very unlikely possibility of) something not working right in the far-flung future than to have to fix the supported version every time a JDK is released (thereby breaking compatibility with previous JDKs at the same time).
