### PR TITLE
Make annotation processor forward-compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.10</version>
+          <version>1.15</version>
           <executions>
               <execution>
                   <phase>package</phase>

--- a/src/main/java/org/kohsuke/metainf_services/AnnotationProcessorImpl.java
+++ b/src/main/java/org/kohsuke/metainf_services/AnnotationProcessorImpl.java
@@ -61,15 +61,7 @@ import org.kohsuke.MetaInfServices;
 public class AnnotationProcessorImpl extends AbstractProcessor {
 
     @Override public SourceVersion getSupportedSourceVersion() {
-        try {
-            // Seems to work. Probably could use some additional error checks, but current code does not even verify that the class is assignable to an explicitly specified type!
-            // Need to add unit tests. See stapler/stapler/core/src/test/java/org/kohsuke/stapler/jsr269/ for examples.
-            return SourceVersion.valueOf("RELEASE_8");
-        } catch (IllegalArgumentException x) {}
-        try {
-            return SourceVersion.valueOf("RELEASE_7");
-        } catch (IllegalArgumentException x) {}
-        return SourceVersion.RELEASE_6;
+        return SourceVersion.latestSupported();
     }
 
     @Override


### PR DESCRIPTION
Removes restrictions requiring an older source version to use this annotation processor. 