### PR TITLE
Automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.kohsuke.metainf-services</groupId>
   <artifactId>metainf-services</artifactId>
-  <version>1.9-SNAPSHOT</version>  
+  <version>1.9-SNAPSHOT</version>
   <name>META-INF/services generator</name>
   <description>Annotation-driven META-INF/services auto-generation</description>
   <url>http://metainf-services.kohsuke.org/</url>
@@ -45,7 +45,7 @@
           <source>1.6</source>
           <target>1.6</target>
           <compilerArgument>-proc:none</compilerArgument>
-         </configuration>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
@@ -64,33 +64,33 @@
         </executions>
       </plugin>
       <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.15</version>
-          <executions>
-              <execution>
-                  <phase>package</phase>
-                  <goals>
-                      <goal>check</goal>
-                  </goals>
-                  <configuration>
-                      <signature>
-                          <groupId>org.codehaus.mojo.signature</groupId>
-                          <artifactId>java16</artifactId>
-                          <version>1.0</version>
-                      </signature>
-                  </configuration>
-              </execution>
-          </executions>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.15</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <signature>
+                <groupId>org.codehaus.mojo.signature</groupId>
+                <artifactId>java16</artifactId>
+                <version>1.0</version>
+              </signature>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
 
   <licenses>
     <license>
-        <name>MIT license</name>
-        <url>http://www.opensource.org/licenses/mit-license.php</url>
-        <distribution>repo</distribution>
+      <name>MIT license</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <distribution>repo</distribution>
     </license>
   </licenses>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,22 @@
          </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Automatic-Module-Name>org.kohsuke.metainf_services</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
           <version>1.15</version>


### PR DESCRIPTION
This PR adds an automatic module name so that modularized Java applications can reliably declare a (compile-time only) dependency on this library. Without this, such applications get the following warning during compilation:

> `Required filename-based automodules detected: [metainf-services-1.8.jar]. Please don't publish this project to a public artifact repository!`

Neither classpath-based applications nor pre-Java 9 applications will be affected.

For more details, see the blog post [Automatic-Module-Name: Calling all Java Library Maintainers](http://branchandbound.net/blog/java/2017/12/automatic-module-name/).

Note: commit 617b79a is the actual change, the other commit only cleans up the POM formatting.