### PR TITLE
Make it work on Java 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kohsuke</groupId>
     <artifactId>pom</artifactId>
-    <version>20</version>
+    <version>21</version>
   </parent>
 
   <groupId>org.kohsuke.metainf-services</groupId>
@@ -40,16 +40,16 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.11.0</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <compilerArgument>-proc:none</compilerArgument>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>default-jar</id>
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
+        <version>1.23</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -76,7 +76,7 @@
             <configuration>
               <signature>
                 <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>java16</artifactId>
+                <artifactId>java18</artifactId>
                 <version>1.0</version>
               </signature>
             </configuration>
@@ -89,7 +89,7 @@
   <licenses>
     <license>
       <name>MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://opensource.org/license/mit/</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/src/main/java/org/kohsuke/MetaInfServices.java
+++ b/src/main/java/org/kohsuke/MetaInfServices.java
@@ -30,10 +30,10 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that this class name should be listed into the <tt>META-INF/services/CONTRACTNAME</tt>.
+ * Indicates that this class name should be listed into the {@code META-INF/services/CONTRACTNAME}.
  *
  * <p>
- * If the class for which this annotation is placaed only have one base class or one interface,
+ * If the class for which this annotation is placed only have one base class or one interface,
  * then the CONTRACTNAME is the fully qualified name of that type.
  *
  * <p>

--- a/src/main/java/org/kohsuke/metainf_services/AnnotationProcessorImpl.java
+++ b/src/main/java/org/kohsuke/metainf_services/AnnotationProcessorImpl.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -105,10 +106,8 @@ public class AnnotationProcessorImpl extends AbstractProcessor {
                 while((line=r.readLine())!=null)
                     e.getValue().add(line);
                 r.close();
-            } catch (FileNotFoundException x) {
+            } catch (FileNotFoundException | NoSuchFileException x) {
                 // doesn't exist
-            } catch (java.nio.file.NoSuchFileException x) {
-               // doesn't exist
             } catch (IOException x) {
                 processingEnv.getMessager().printMessage(Kind.ERROR,"Failed to load existing service definition files: "+x);
             }

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,7 +3,7 @@
   <skin>
     <groupId>org.kohsuke</groupId>
     <artifactId>maven-skin</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
   </skin>
 
   <body>


### PR DESCRIPTION
Hey @kohsuke,

I'm currently investigating into Java 21 compatibility in Jenkins core and tooling, and stumbled apart issues related to metainf-services.
I'm unable to isolate it, but modern maven got stricter in various areas, and I'm able to get a green build with the changes proposed. Therefore, I gave it a shot \o/

I hope you don't mind bumping the minimum Java version to 8, modern maven doesn't support anything older.